### PR TITLE
Align sponsor funnel with GitHub app installation

### DIFF
--- a/app/app/attach-bounty/page.jsx
+++ b/app/app/attach-bounty/page.jsx
@@ -72,6 +72,8 @@ function AttachBountyContent() {
   
   // Date picker modal state
   const [dateModalOpen, setDateModalOpen] = useState(false);
+  const hasTokenChoice = multiTokenEnabled && availableTokens.length > 1;
+  const showFundingControls = hasTokenChoice || !isChainSupported;
 
   if (!isMounted) {
     return <AttachBountyLoadingState />;
@@ -130,50 +132,35 @@ function AttachBountyContent() {
               supportedNetworkNames={supportedNetworkNames}
             />
 
-            {/* Wallet/account actions (change wallet, network, or token) */}
-            <ConnectButton.Custom>
-              {({ openConnectModal, openChainModal, openAccountModal }) => {
-                return (
-                  <div className="grid gap-3 md:grid-cols-3">
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        if (openAccountModal) {
-                          openAccountModal();
-                        } else {
-                          openConnectModal?.();
-                        }
-                      }}
-                      disabled={!isMounted}
-                      className="inline-flex items-center justify-center rounded-full border border-border/70 px-6 py-3 text-sm font-medium text-foreground transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      Change Wallet
-                    </button>
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        openChainModal?.();
-                      }}
-                      disabled={!isMounted || !openChainModal}
-                      className="inline-flex items-center justify-center rounded-full border border-border/70 px-6 py-3 text-sm font-medium text-foreground transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      Switch Network
-                    </button>
-                    {/* Always show token selector button */}
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setTokenModalOpen(true);
-                      }}
-                      disabled={!isMounted}
-                      className="inline-flex items-center justify-center rounded-full border border-border/70 px-6 py-3 text-sm font-medium text-foreground transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {selectedToken?.symbol || network?.token?.symbol || 'Token'}
-                    </button>
-                  </div>
-                );
-              }}
-            </ConnectButton.Custom>
+            {showFundingControls ? (
+              <div className="flex flex-wrap gap-3">
+                {!isChainSupported ? (
+                  <ConnectButton.Custom>
+                    {({ openChainModal }) => (
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          openChainModal?.();
+                        }}
+                        disabled={!isMounted || !openChainModal}
+                        className="inline-flex items-center justify-center rounded-full border border-border/70 px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Switch Network
+                      </button>
+                    )}
+                  </ConnectButton.Custom>
+                ) : null}
+                {hasTokenChoice ? (
+                  <button
+                    onClick={() => setTokenModalOpen(true)}
+                    disabled={!isMounted}
+                    className="inline-flex items-center justify-center rounded-full border border-border/70 px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Token: {selectedToken?.symbol || network?.token?.symbol || 'Token'}
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
 
             {/* Token selector modal */}
             <TokenSelectorModal

--- a/app/app/attach-bounty/page.jsx
+++ b/app/app/attach-bounty/page.jsx
@@ -5,10 +5,9 @@
  * Handles main logic and view for connecting wallet, setting bounty amount and deadline.
  */
 
-import { useMemo, Suspense, useEffect, useState, useRef, useCallback } from 'react';
+import { useMemo, Suspense, useState, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import BetaAccessModal from '@/ui/pages/beta/BetaAccessModal';
 import StatusNotice from '@/ui/components/StatusNotice';
 import TokenSelectorModal from '@/ui/components/TokenSelectorModal';
 import DatePickerModal from '@/ui/components/DatePickerModal';
@@ -49,10 +48,6 @@ function AttachBountyContent() {
     status,
     isProcessing,
     isMounted,
-    showBetaModal,
-    betaLoading,
-    hasAccess,
-    hideBetaModal,
     supportedNetworkNames,
     isChainSupported,
     network,
@@ -61,7 +56,6 @@ function AttachBountyContent() {
     wallet,
     hasIssueData,
     fundBounty,
-    betaProgramEnabled,
     // Token selection (multi-token support)
     availableTokens,
     selectedToken,
@@ -72,87 +66,20 @@ function AttachBountyContent() {
 
   // Navigate back (or push) handler - wrapped in useCallback for stability
   const handleBack = useCallback(() => goBackOrPush(router), [router]);
-
-  // Track if modal was opened - once opened, keep it open until dismissed or access granted
-  // This prevents flickering when beta access state updates during loading
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-  const modalOpenedRef = useRef(false);
   
   // Token selector modal state
   const [tokenModalOpen, setTokenModalOpen] = useState(false);
   
   // Date picker modal state
   const [dateModalOpen, setDateModalOpen] = useState(false);
-  
-  useEffect(() => {
-    // Only update when not loading and conditions change
-    if (betaLoading) return;
-    
-    // Open modal if user doesn't have access and showBetaModal is true
-    if (!hasAccess && showBetaModal && !modalOpenedRef.current) {
-      setModalIsOpen(true);
-      modalOpenedRef.current = true;
-    }
-    // Close modal if access is granted
-    if (hasAccess && modalOpenedRef.current) {
-      setModalIsOpen(false);
-      modalOpenedRef.current = false;
-    }
-  }, [betaLoading, hasAccess, showBetaModal]); // Removed modalIsOpen from deps to prevent circular updates
 
-  // Stable callback for modal close - prevents flickering from inline function re-creation
-  const handleModalClose = useCallback(() => {
-    setModalIsOpen(false);
-    modalOpenedRef.current = false;
-    hideBetaModal();
-    handleBack();
-  }, [hideBetaModal, handleBack]);
-
-  // Stable callback for access granted - prevents flickering from inline function re-creation
-  const handleAccessGranted = useCallback(() => {
-    setModalIsOpen(false);
-    modalOpenedRef.current = false;
-    hideBetaModal();
-    // Refresh the page to update beta access state
-    // Use a small delay to ensure modal closes smoothly
-    setTimeout(() => {
-      router.refresh();
-    }, 100);
-  }, [hideBetaModal, router]);
-
-  /**
-   * Modal for beta access.
-   * Shown if user does not have access.
-   * Once opened, stays open until dismissed or access is granted (prevents flickering during loading).
-   */
-  const betaModal = betaProgramEnabled ? (
-    <BetaAccessModal
-      isOpen={modalIsOpen}
-      onClose={handleModalClose}
-      onDismiss={handleModalClose}
-      dismissLabel="Back"
-      onAccessGranted={handleAccessGranted}
-    />
-  ) : null;
-
-  // Show a loading state while mounting or fetching beta status
-  if (!isMounted || betaLoading) {
-    return (
-      <>
-        <AttachBountyLoadingState />
-        {betaModal}
-      </>
-    );
+  if (!isMounted) {
+    return <AttachBountyLoadingState />;
   }
 
   // If visiting directly (no issue info), show direct setup section
   if (!hasIssueData) {
-    return (
-      <>
-        <DirectSetupSection onBack={handleBack} />
-        {betaModal}
-      </>
-    );
+    return <DirectSetupSection onBack={handleBack} />;
   }
 
   // Show the Attach Bounty form and flow
@@ -340,7 +267,6 @@ function AttachBountyContent() {
         {/* Status and error/info messages */}
         <StatusNotice status={status} />
       </div>
-      {betaModal}
     </div>
   );
 }

--- a/config/chain-registry.js
+++ b/config/chain-registry.js
@@ -3,6 +3,7 @@ import { isAddress } from 'ethers';
 import { getLinkHref } from '@/config/links';
 
 let hasLoggedSkippedAliases = false;
+let hasLoggedMissingRegistry = false;
 
 // Curated network aliases with baseline configuration
 const CURATED_ALIASES = {
@@ -281,14 +282,12 @@ function buildRegistry() {
   }
 
   if (Object.keys(registry).length === 0) {
-    // On client-side, return empty registry to prevent crashes
-    // On server-side, throw error to fail fast for misconfiguration
-    const isClient = typeof window !== 'undefined';
-    if (isClient) {
+    // Allow the app to boot without blockchain env so routes can fail at request time.
+    if (!hasLoggedMissingRegistry) {
       logger.warn('[chain-registry] No networks configured. Set BLOCKCHAIN_SUPPORTED_MAINNET_ALIASES and/or BLOCKCHAIN_SUPPORTED_TESTNET_ALIASES');
-      return registry; // Return empty registry
+      hasLoggedMissingRegistry = true;
     }
-    throw new Error('No networks configured. Set BLOCKCHAIN_SUPPORTED_MAINNET_ALIASES and/or BLOCKCHAIN_SUPPORTED_TESTNET_ALIASES');
+    return registry;
   }
 
   return registry;

--- a/integrations/github/constants.js
+++ b/integrations/github/constants.js
@@ -1,7 +1,7 @@
 import { CONFIG } from '@/server/config.js';
 import { getLinkHref } from '@/config/links';
 
-export const FRONTEND_BASE = CONFIG.frontendUrl.replace(/\/$/, '');
+export const FRONTEND_BASE = (CONFIG.frontendUrl || getLinkHref('app', 'marketingSite')).replace(/\/$/, '');
 export const CTA_BUTTON = `${FRONTEND_BASE}/buttons/create-bounty.svg`;
 export const OG_ICON = `${FRONTEND_BASE}/icons/og.png`;
 export const BRAND_SIGNATURE =

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,90 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { LINKS } from '../config/links.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const sourceExtensions = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const excludedDirectories = new Set(['.git', '.next', 'node_modules']);
+
+function hasCatalogEntry(section, link) {
+  return Boolean(LINKS?.[section]?.[link]);
+}
+
+async function collectSourceFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (excludedDirectories.has(entry.name)) {
+      continue;
+    }
+
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectSourceFiles(fullPath));
+      continue;
+    }
+
+    if (sourceExtensions.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function collectLinkReferences(contents) {
+  const references = [];
+  const catalogComponentPattern = /<LinkFromCatalog\b[\s\S]*?\bsection="([^"]+)"[\s\S]*?\blink="([^"]+)"/g;
+  const catalogHelperPattern = /\b(?:getLinkHref|getLinkMeta|resolveLink)\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]/g;
+
+  for (const match of contents.matchAll(catalogComponentPattern)) {
+    references.push({ section: match[1], link: match[2], source: 'LinkFromCatalog' });
+  }
+
+  for (const match of contents.matchAll(catalogHelperPattern)) {
+    references.push({ section: match[1], link: match[2], source: 'link helper' });
+  }
+
+  return references;
+}
+
+async function main() {
+  const files = await collectSourceFiles(repoRoot);
+  const errors = [];
+  let referenceCount = 0;
+
+  for (const filePath of files) {
+    const contents = await readFile(filePath, 'utf8');
+    const references = collectLinkReferences(contents);
+
+    for (const reference of references) {
+      referenceCount += 1;
+      if (hasCatalogEntry(reference.section, reference.link)) {
+        continue;
+      }
+
+      errors.push(
+        `${path.relative(repoRoot, filePath)}: unknown ${reference.source} reference ${reference.section}.${reference.link}`
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('Link catalog validation failed.');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Validated ${referenceCount} catalog link references.`);
+}
+
+main().catch((error) => {
+  console.error('Link catalog validation failed.');
+  console.error(error);
+  process.exit(1);
+});

--- a/server/config.js
+++ b/server/config.js
@@ -183,7 +183,7 @@ export function validateConfig() {
     errors.push('Missing required config: PROD_CALLBACK_URL (required when ENV_TARGET=prod)');
   }
 
-  // Validate REGISTRY was built successfully (chain-registry.js throws on build errors)
+  // Validate REGISTRY was built successfully
   if (Object.keys(REGISTRY).length === 0) {
     errors.push('No blockchain networks configured. Check BLOCKCHAIN_SUPPORTED_*_ALIASES environment variables.');
   }

--- a/ui/hooks/useAttachBountyForm.js
+++ b/ui/hooks/useAttachBountyForm.js
@@ -1,10 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ethers } from 'ethers';
 import { useAccount, useWalletClient, useSwitchChain } from 'wagmi';
 import { useNetwork } from '@/ui/providers/NetworkProvider';
-import { useBetaAccess } from '@/ui/hooks/useBetaAccess';
 import { useErrorModal } from '@/ui/providers/ErrorModalProvider';
 import { useFlag } from '@/ui/providers/FlagProvider';
 import { fundBounty } from '@/ui/pages/bounty/lib/fundBounty';
@@ -13,7 +12,7 @@ import { logger } from '@/lib/logger';
 /**
  * React hook for managing the state and logic of the Attach Bounty form.
  *
- * Handles input values, network selection, token selection, beta access, and bounty funding flow.
+ * Handles input values, network selection, token selection, and the bounty funding flow.
  *
  * @param {Object} params
  * @param {Object} params.issueData - Data about the GitHub issue.
@@ -30,9 +29,6 @@ export function useAttachBountyForm({ issueData }) {
   // Processing state for funding
   const [isProcessing, setIsProcessing] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
-  // Beta modal control
-  const [showBetaModal, setShowBetaModal] = useState(false);
-  const modalOpenedRef = useRef(false);
   // Fee state (bps) for funding breakdown
   const [feeBps, setFeeBps] = useState(100);
   // Multi-token feature flag
@@ -42,7 +38,6 @@ export function useAttachBountyForm({ issueData }) {
   const { address, isConnected, chain } = useAccount();
   const { data: walletClient } = useWalletClient();
   const { switchChain } = useSwitchChain();
-  const { hasAccess, betaStatus, loading: betaLoading, betaProgramEnabled } = useBetaAccess();
   const { showError } = useErrorModal();
   const {
     registry,
@@ -103,31 +98,6 @@ export function useAttachBountyForm({ issueData }) {
   useEffect(() => {
     setIsMounted(true);
   }, []);
-
-  /**
-   * Updates the visibility of the beta access modal
-   * depending on user access state.
-   * Once the modal is opened, keep it open until access is granted or user dismisses it.
-   */
-  useEffect(() => {
-    if (!betaProgramEnabled) {
-      setShowBetaModal(false);
-      modalOpenedRef.current = false;
-      return;
-    }
-
-    if (!betaLoading) {
-      // Only update if modal hasn't been opened yet, or if access was just granted
-      if (!modalOpenedRef.current && !hasAccess) {
-        setShowBetaModal(true);
-        modalOpenedRef.current = true;
-      } else if (hasAccess && modalOpenedRef.current) {
-        // Access was granted, close modal and reset ref
-        setShowBetaModal(false);
-        modalOpenedRef.current = false;
-      }
-    }
-  }, [betaLoading, hasAccess, betaProgramEnabled]);
 
   /**
    * Keeps selectedAlias in sync with the current network and registry settings.
@@ -336,13 +306,6 @@ export function useAttachBountyForm({ issueData }) {
     status,
     isProcessing,
     isMounted,
-    showBetaModal,
-    betaLoading,
-    hasAccess,
-    hideBetaModal: () => {
-      setShowBetaModal(false);
-      modalOpenedRef.current = false;
-    },
     supportedNetworkNames,
     isChainSupported,
     network,
@@ -359,8 +322,6 @@ export function useAttachBountyForm({ issueData }) {
       isConnected,
       chain
     },
-    betaStatus,
-    betaProgramEnabled,
     hasIssueData,
     fundBounty: handleFundBounty,
     showStatus

--- a/ui/pages/bounty/AttachBountySections.jsx
+++ b/ui/pages/bounty/AttachBountySections.jsx
@@ -34,22 +34,22 @@ export function DirectSetupSection({ onBack }) {
           ← Back
         </button>
         <div className="text-center space-y-3">
-          <h1 className="text-4xl font-light text-foreground/90">Create Bounty</h1>
+          <h1 className="text-4xl font-light text-foreground/90">Install BountyPay on GitHub</h1>
           <p className="text-sm text-muted-foreground">
-            Install the Lucci GitHub App to start funding issues directly from GitHub.
+            Install the BountyPay GitHub App once, then fund issues directly from GitHub.
           </p>
         </div>
 
         <div className="rounded-3xl border border-border/60 bg-muted/40 p-6 space-y-4">
           <div className="space-y-2">
-            <h3 className="text-base font-medium text-foreground">Install GitHub App</h3>
+            <h3 className="text-base font-medium text-foreground">Start with installation</h3>
             <p className="text-sm text-muted-foreground">
               Add BountyPay to your repo, then trigger the “Attach Bounty” action from any issue.
             </p>
           </div>
           <LinkFromCatalog
             section="github"
-            link="appListing"
+            link="appInstallation"
             className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
           >
             <GitHubIcon size={18} color="white" />
@@ -58,7 +58,7 @@ export function DirectSetupSection({ onBack }) {
         </div>
 
         <div className="rounded-3xl border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
-          Once installed, open any issue and hit “Attach Bounty” to land back on this page with the issue pre-filled.
+          After installation, open any issue on GitHub and click “Attach Bounty” to come back here with the issue pre-filled.
         </div>
       </div>
     </div>

--- a/ui/pages/home/LandingPage.jsx
+++ b/ui/pages/home/LandingPage.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { LinkFromCatalog } from '@/ui/components/LinkFromCatalog';
 
 // Custom hook for intersection observer
 function useInView(options = {}) {
@@ -82,23 +83,31 @@ function HeroSection() {
       <div className="relative z-10 max-w-6xl mx-auto px-6 text-center">
         {/* Main headline - Larger serif */}
         <h1 className="font-instrument-serif text-6xl md:text-7xl lg:text-8xl text-foreground mb-5 leading-[1.1] tracking-tight">
-          Open source contributions,
+          Fund GitHub issues,
           <br />
-          <span className="italic">rewarded instantly</span>
+          <span className="italic">pay only when merged</span>
         </h1>
         
         {/* Subheadline - Smaller */}
         <p className="text-sm md:text-base text-muted-foreground max-w-lg mx-auto mb-8 leading-relaxed">
-          Fund GitHub issues with crypto bounties. Contributors get paid automatically when their pull requests merge.
+          Install BountyPay once, fund issues directly from GitHub, and release payment automatically when the pull request merges.
         </p>
         
-        {/* Single CTA Button - Completely rounded */}
-        <Link 
-          href="/app" 
-          className="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground text-sm font-medium rounded-full transition-all duration-300 hover:opacity-90 hover:shadow-lg"
-        >
-          Get started
-        </Link>
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <LinkFromCatalog
+            section="github"
+            link="appInstallation"
+            className="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground text-sm font-medium rounded-full transition-all duration-300 hover:opacity-90 hover:shadow-lg"
+          >
+            Install GitHub App
+          </LinkFromCatalog>
+          <Link
+            href="/app"
+            className="inline-flex items-center justify-center px-6 py-3 border border-border bg-card/80 text-foreground text-sm font-medium rounded-full transition-colors hover:border-primary"
+          >
+            Browse open bounties
+          </Link>
+        </div>
       </div>
 
       {/* Product mockup - GitHub issue comments style */}
@@ -540,7 +549,7 @@ function FAQSection() {
   const faqs = [
     {
       question: 'How do I fund a bounty?',
-      answer: 'Connect your wallet, select a GitHub issue, set the bounty amount and deadline, then confirm the transaction. Your funds are securely held in escrow until the work is completed.'
+      answer: 'Install the BountyPay GitHub App, open the GitHub issue you want to fund, click Attach Bounty, choose the amount and deadline, and confirm the transaction. Funds stay in escrow until the pull request merges.'
     },
     {
       question: 'Which cryptocurrencies are supported?',
@@ -636,17 +645,18 @@ function CTASection() {
           <h2 className="font-instrument-serif text-4xl md:text-5xl lg:text-5xl text-foreground mb-5 leading-tight">
             Ready to fund your first
             <br />
-            <span className="italic">bounty?</span>
+            <span className="italic">issue?</span>
           </h2>
           <p className="text-sm text-muted-foreground mb-8 max-w-md mx-auto">
-            Join the growing community of sponsors and contributors building the future of open source.
+            Install once, fund from GitHub, and pay contributors automatically when their code lands.
           </p>
-          <Link 
-            href="/app/attach-bounty" 
+          <LinkFromCatalog
+            section="github"
+            link="appInstallation"
             className="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground text-sm font-medium rounded-full transition-all duration-300 hover:opacity-90 hover:shadow-lg"
           >
-            Create a bounty
-          </Link>
+            Install GitHub App
+          </LinkFromCatalog>
         </div>
       </AnimateOnScroll>
     </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- redirect sponsor-facing landing page CTAs to direct GitHub App installation while keeping a separate browse-bounties path for contributors
- rewrite funding/install copy so the homepage and attach-bounty setup screen describe the real maintainer flow and remove the stale Lucci naming
- harden build-time config handling so missing blockchain aliases or `FRONTEND_URL` do not crash route imports, and restore `npm run lint:links` with a real static link-catalog checker
- remove beta approval and beta-loading gates from the attach-bounty funding flow so sponsors can connect a wallet and fund immediately
- refine the connected-wallet funding UI so only context-sensitive controls remain: switch network when required, choose token only when there is a real choice

## Verification
- `npm install && npm run build && npm run lint:links`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cbab554-163a-40f1-bdaf-8bdd86759eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cbab554-163a-40f1-bdaf-8bdd86759eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

