### PR TITLE
Refactor wallet linking to use session data instead of request body

### DIFF
--- a/app/api/wallet/link/route.js
+++ b/app/api/wallet/link/route.js
@@ -2,30 +2,31 @@ import { logger } from '@/lib/logger';
 import { getSession } from '@/lib/session';
 import { walletQueries } from '@/server/db/prisma';
 
-export async function POST(request) {
+// Links the SIWE-verified wallet in the session to the OAuth-verified GitHub
+// identity in the session. Inputs are taken exclusively from the session —
+// the request body is ignored — so a caller cannot link a wallet to anyone
+// else's GitHub account or overwrite another user's wallet mapping.
+export async function POST() {
   try {
     const session = await getSession();
-    const { githubId, githubUsername, walletAddress } = await request.json();
 
-    if (!githubId || !githubUsername || !walletAddress) {
-      return Response.json({ error: 'Missing required fields' }, { status: 400 });
+    if (!session.githubId || !session.githubUsername) {
+      return Response.json({ error: 'Not authenticated' }, { status: 401 });
     }
 
-    // Verify wallet is authenticated in session
-    if (session.walletAddress?.toLowerCase() !== walletAddress.toLowerCase()) {
+    if (!session.walletAddress) {
       return Response.json({ error: 'Wallet not authenticated' }, { status: 401 });
     }
 
-    // Store mapping
-    await walletQueries.create(githubId, githubUsername, walletAddress);
+    await walletQueries.create(
+      session.githubId,
+      session.githubUsername,
+      session.walletAddress
+    );
 
-    return Response.json({
-      success: true,
-      message: 'Wallet linked successfully'
-    });
+    return Response.json({ success: true });
   } catch (error) {
     logger.error('Error linking wallet:', error);
-    return Response.json({ error: error.message }, { status: 500 });
+    return Response.json({ error: 'Failed to link wallet' }, { status: 500 });
   }
 }
-


### PR DESCRIPTION
## Summary
Refactored the wallet linking endpoint to extract authentication data exclusively from the session rather than accepting it from the request body. This improves security by preventing callers from linking wallets to arbitrary GitHub accounts.

## Key Changes
- Removed `request` parameter and stopped parsing request body JSON
- Changed to read `githubId`, `githubUsername`, and `walletAddress` directly from the session object
- Updated validation logic to check session fields instead of request body fields
- Simplified error responses and removed unnecessary success message details
- Added comprehensive JSDoc comment explaining the security model and data source

## Implementation Details
- The endpoint now validates that both GitHub authentication (`githubId`, `githubUsername`) and wallet authentication (`walletAddress`) exist in the session before proceeding
- Returns 401 "Not authenticated" if GitHub credentials are missing
- Returns 401 "Wallet not authenticated" if wallet address is missing
- Removed the wallet address comparison check since the wallet is already verified during session establishment
- Simplified error handling to return a generic "Failed to link wallet" message instead of exposing error details