### PR TITLE
Add test suite for money-critical logic and fix deadline off-by-one

### DIFF
--- a/integrations/github/client.js
+++ b/integrations/github/client.js
@@ -1,6 +1,7 @@
 import { logger } from '@/lib/logger';
 import { App } from 'octokit';
 import { CONFIG } from '@/server/config.js';
+import { extractClosedIssues, extractMentionedIssues } from './issueRefs.js';
 
 let githubApp;
 
@@ -168,33 +169,9 @@ export async function getPR(octokit, owner, repo, prNumber) {
   return data;
 }
 
-/**
- * Check if PR closes an issue (parse PR body for "Closes #123")
- */
-export function extractClosedIssues(prBody) {
-  if (!prBody) return [];
-  
-  // Match variations: Closes #123, Fixes #456, Resolves #789
-  const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
-  const matches = [...prBody.matchAll(regex)];
-  
-  return matches.map(match => parseInt(match[1]));
-}
-
-/**
- * Extract ALL issue numbers mentioned in PR title or body
- */
-export function extractMentionedIssues(prTitle, prBody) {
-  const text = `${prTitle} ${prBody || ''}`;
-  if (!text) return [];
-  
-  // Match any #123 pattern
-  const regex = /#(\d+)/g;
-  const matches = [...text.matchAll(regex)];
-  
-  // Return unique issue numbers
-  return [...new Set(matches.map(match => parseInt(match[1])))];
-}
+// Issue-reference parsing lives in ./issueRefs.js (pure, dependency-free).
+// Re-exported here for backwards compatibility with existing imports.
+export { extractClosedIssues, extractMentionedIssues };
 
 /**
  * Get user details

--- a/integrations/github/issueRefs.js
+++ b/integrations/github/issueRefs.js
@@ -1,0 +1,42 @@
+/**
+ * Pure helpers for parsing GitHub issue references out of pull-request text.
+ *
+ * These functions decide WHICH bounty a pull request is claiming, so they sit
+ * directly on the money path. They are intentionally dependency-free (no
+ * octokit, no env config) so they can be unit tested in isolation.
+ */
+
+/**
+ * Extract issue numbers a PR explicitly closes via GitHub's closing keywords
+ * (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved).
+ *
+ * @param {string} prBody - The pull request body/description.
+ * @returns {number[]} Issue numbers in the order they appear (may contain duplicates).
+ */
+export function extractClosedIssues(prBody) {
+  if (!prBody) return [];
+
+  // Match variations: Closes #123, Fixes #456, Resolves #789
+  const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+  const matches = [...prBody.matchAll(regex)];
+
+  return matches.map((match) => parseInt(match[1], 10));
+}
+
+/**
+ * Extract ALL issue numbers mentioned (#123) in a PR title or body.
+ *
+ * @param {string} prTitle - The pull request title.
+ * @param {string} [prBody] - The pull request body/description.
+ * @returns {number[]} Unique issue numbers, in first-seen order.
+ */
+export function extractMentionedIssues(prTitle, prBody) {
+  const text = `${prTitle ?? ''} ${prBody || ''}`;
+
+  // Match any #123 pattern
+  const regex = /#(\d+)/g;
+  const matches = [...text.matchAll(regex)];
+
+  // Return unique issue numbers
+  return [...new Set(matches.map((match) => parseInt(match[1], 10)))];
+}

--- a/lib/status/index.js
+++ b/lib/status/index.js
@@ -67,7 +67,10 @@ export function getStatusLabel(status) {
 export function deriveLifecycle(bounty, nowSeconds = Math.floor(Date.now() / 1000)) {
   const deadlineSeconds = Number(bounty?.deadline);
   const hasDeadline = Number.isFinite(deadlineSeconds);
-  const deadlinePassed = hasDeadline && deadlineSeconds <= nowSeconds;
+  // Match BountyEscrow.sol: refundExpired requires block.timestamp > deadline
+  // (strict), and resolve is still allowed at block.timestamp == deadline. So a
+  // bounty only counts as expired once now is strictly past the deadline.
+  const deadlinePassed = hasDeadline && nowSeconds > deadlineSeconds;
   const status = bounty?.status;
   const isTerminal = isTerminalStatus(status);
 
@@ -108,6 +111,9 @@ export function deriveLifecycle(bounty, nowSeconds = Math.floor(Date.now() / 100
 export function isRefundEligible(bounty, nowSeconds = Math.floor(Date.now() / 1000)) {
   if (bounty?.status !== 'open') return false;
   const deadline = Number(bounty?.deadline);
-  return Number.isFinite(deadline) && deadline <= nowSeconds;
+  // Strictly past the deadline, mirroring the contract's refundExpired guard
+  // (block.timestamp > deadline). At exactly the deadline an on-chain refund
+  // would revert with DeadlineNotReached, so it is not yet eligible.
+  return Number.isFinite(deadline) && nowSeconds > deadline;
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production prisma generate --schema server/db/schema.prisma && cross-env NODE_ENV=production next build",
     "start": "next start",
     "postinstall": "prisma generate --schema server/db/schema.prisma",
-    "test": "node --test tests/",
+    "test": "node --test \"tests/**/*.test.js\"",
     "lint:links": "node scripts/check-links.mjs"
   },
   "keywords": [

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -1,0 +1,115 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatAmount, TOKEN_DECIMALS } from '../lib/format/amount.js';
+import { formatStarCount } from '../lib/format/stars.js';
+import { capitalizeFirst } from '../lib/format/text.js';
+import { encodeBadgeSegment, buildShieldsBadge, buildBadgeLink } from '../lib/format/badge.js';
+import { formatTimeLeft, formatTimeRemaining, formatDeadlineDate } from '../lib/format/time.js';
+
+test('TOKEN_DECIMALS encodes the supported tokens', () => {
+  assert.equal(TOKEN_DECIMALS.USDC, 6);
+  assert.equal(TOKEN_DECIMALS.MUSD, 18);
+});
+
+test('formatAmount converts USDC base units (6 decimals)', () => {
+  assert.equal(formatAmount('1000000', 'USDC'), '1');
+  assert.equal(formatAmount('1500000', 'USDC', { maximumFractionDigits: 2 }), '1.5');
+  assert.equal(formatAmount(2500000, 'USDC', { minimumFractionDigits: 2 }), '2.50');
+});
+
+test('formatAmount converts MUSD base units (18 decimals)', () => {
+  assert.equal(formatAmount('1000000000000000000', 'MUSD'), '1');
+  assert.equal(
+    formatAmount('2500000000000000000', 'MUSD', { maximumFractionDigits: 2 }),
+    '2.5'
+  );
+});
+
+test('formatAmount defaults unknown tokens to 6 decimals', () => {
+  assert.equal(formatAmount('1000000', 'WAT'), '1');
+});
+
+test('formatAmount returns "0" for nullish or non-finite input', () => {
+  assert.equal(formatAmount(null, 'USDC'), '0');
+  assert.equal(formatAmount(undefined, 'USDC'), '0');
+  assert.equal(formatAmount('not-a-number', 'USDC'), '0');
+});
+
+test('formatAmount honours an explicit decimals override', () => {
+  assert.equal(formatAmount('100', 'USDC', { decimals: 2 }), '1');
+});
+
+test('formatStarCount abbreviates thousands and handles nullish input', () => {
+  assert.equal(formatStarCount(0), '0');
+  assert.equal(formatStarCount(999), '999');
+  assert.equal(formatStarCount(1000), '1.0k');
+  assert.equal(formatStarCount(1500), '1.5k');
+  assert.equal(formatStarCount(null), '0');
+  assert.equal(formatStarCount(undefined), '0');
+});
+
+test('capitalizeFirst capitalizes only the first character', () => {
+  assert.equal(capitalizeFirst('open'), 'Open');
+  assert.equal(capitalizeFirst('a'), 'A');
+  assert.equal(capitalizeFirst(''), '');
+  assert.equal(capitalizeFirst('alreadyCapitalCamel'), 'AlreadyCapitalCamel');
+});
+
+test('encodeBadgeSegment escapes dashes per shields.io rules', () => {
+  assert.equal(encodeBadgeSegment('a-b'), 'a--b');
+  assert.equal(encodeBadgeSegment('hello world'), 'hello%20world');
+});
+
+test('buildShieldsBadge builds a markdown image and requires a baseUrl', () => {
+  const badge = buildShieldsBadge({
+    baseUrl: 'https://img.shields.io/badge',
+    label: 'bounty',
+    value: '$100'
+  });
+  assert.match(badge, /^!\[bounty \$100\]\(https:\/\/img\.shields\.io\/badge\/bounty-/);
+  assert.match(badge, /style=for-the-badge/);
+  assert.throws(() => buildShieldsBadge({ label: 'x', value: 'y' }), /requires a baseUrl/);
+});
+
+test('buildBadgeLink wraps markdown in a link and degrades gracefully', () => {
+  assert.equal(buildBadgeLink('![x](y)', 'https://e.com'), '[![x](y)](https://e.com)');
+  assert.equal(buildBadgeLink('![x](y)', ''), '![x](y)');
+  assert.equal(buildBadgeLink('', 'https://e.com'), '');
+});
+
+test('formatTimeLeft summarises the time until a deadline', () => {
+  const now = Date.now();
+  // Add slack so flooring stays stable across the elapsed test time.
+  const inDays = Math.floor((now + (3 * 24 + 1) * 3600 * 1000) / 1000);
+  const inHours = Math.floor((now + (5 * 3600 + 30 * 60) * 1000) / 1000);
+  const soon = Math.floor((now + 30 * 60 * 1000) / 1000);
+  const past = Math.floor((now - 3600 * 1000) / 1000);
+
+  assert.equal(formatTimeLeft(inDays), '3d');
+  assert.equal(formatTimeLeft(inHours), '5h');
+  assert.equal(formatTimeLeft(soon), '< 1h');
+  assert.equal(formatTimeLeft(past), 'Expired');
+  assert.equal(formatTimeLeft(null), '-');
+});
+
+test('formatTimeRemaining expands the short labels into prose', () => {
+  const now = Date.now();
+  const inOneDay = Math.floor((now + 1.2 * 24 * 3600 * 1000) / 1000);
+  const inTwoDays = Math.floor((now + 2.2 * 24 * 3600 * 1000) / 1000);
+  const inOneHour = Math.floor((now + 1.2 * 3600 * 1000) / 1000);
+  const soon = Math.floor((now + 20 * 60 * 1000) / 1000);
+
+  assert.equal(formatTimeRemaining(inOneDay), '1 day');
+  assert.equal(formatTimeRemaining(inTwoDays), '2 days');
+  assert.equal(formatTimeRemaining(inOneHour), '1 hour');
+  assert.equal(formatTimeRemaining(soon), 'Less than 1h');
+  assert.equal(formatTimeRemaining(null), 'Unknown');
+});
+
+test('formatDeadlineDate renders a date and guards against bad input', () => {
+  // 2021-01-01T00:00:00Z = 1609459200 (assert on year to stay timezone-agnostic)
+  assert.match(formatDeadlineDate(1609459200, { locale: 'en-US' }), /2020|2021/);
+  assert.equal(formatDeadlineDate(null), '-');
+  assert.equal(formatDeadlineDate('not-a-date'), '-');
+});

--- a/tests/issueRefs.test.js
+++ b/tests/issueRefs.test.js
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractClosedIssues, extractMentionedIssues } from '../integrations/github/issueRefs.js';
+
+test('extractClosedIssues returns [] for empty/missing bodies', () => {
+  assert.deepEqual(extractClosedIssues(''), []);
+  assert.deepEqual(extractClosedIssues(null), []);
+  assert.deepEqual(extractClosedIssues(undefined), []);
+});
+
+test('extractClosedIssues recognises every GitHub closing keyword', () => {
+  assert.deepEqual(extractClosedIssues('Closes #1'), [1]);
+  assert.deepEqual(extractClosedIssues('close #2'), [2]);
+  assert.deepEqual(extractClosedIssues('closed #3'), [3]);
+  assert.deepEqual(extractClosedIssues('Fix #4'), [4]);
+  assert.deepEqual(extractClosedIssues('fixes #5'), [5]);
+  assert.deepEqual(extractClosedIssues('fixed #6'), [6]);
+  assert.deepEqual(extractClosedIssues('Resolve #7'), [7]);
+  assert.deepEqual(extractClosedIssues('resolves #8'), [8]);
+  assert.deepEqual(extractClosedIssues('resolved #9'), [9]);
+});
+
+test('extractClosedIssues is case-insensitive and finds multiple references', () => {
+  assert.deepEqual(extractClosedIssues('CLOSES #10 and Fixes #11'), [10, 11]);
+});
+
+test('extractClosedIssues ignores bare mentions without a closing keyword', () => {
+  assert.deepEqual(extractClosedIssues('See #42 for context'), []);
+  assert.deepEqual(extractClosedIssues('Related to #7, but does not fix it'), []);
+});
+
+test('extractClosedIssues does not treat substrings like "prefix" as keywords', () => {
+  // "affixes" ends in "fixes" but should not match because of the word boundary
+  // created by requiring whitespace before the '#'.
+  assert.deepEqual(extractClosedIssues('This affixes#12 a label'), []);
+});
+
+test('extractMentionedIssues collects all #refs and dedupes preserving order', () => {
+  assert.deepEqual(extractMentionedIssues('Fixes #3', 'Also touches #1 and #3 again'), [3, 1]);
+});
+
+test('extractMentionedIssues reads from both title and body', () => {
+  assert.deepEqual(extractMentionedIssues('#5 in title', 'and #6 in body'), [5, 6]);
+});
+
+test('extractMentionedIssues tolerates missing title or body', () => {
+  assert.deepEqual(extractMentionedIssues(undefined, '#8'), [8]);
+  assert.deepEqual(extractMentionedIssues('#9', undefined), [9]);
+  assert.deepEqual(extractMentionedIssues('', ''), []);
+  assert.deepEqual(extractMentionedIssues(undefined, undefined), []);
+});
+
+test('parsed issue numbers are integers, not strings', () => {
+  const [closed] = extractClosedIssues('Closes #123');
+  assert.equal(closed, 123);
+  assert.equal(typeof closed, 'number');
+
+  const [mentioned] = extractMentionedIssues('#456', '');
+  assert.equal(typeof mentioned, 'number');
+});

--- a/tests/status.test.js
+++ b/tests/status.test.js
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BOUNTY_STATUS,
+  CONTRACT_STATUS_MAP,
+  isValidStatus,
+  isTerminalStatus,
+  contractStatusToDb,
+  getStatusLabel,
+  deriveLifecycle,
+  isRefundEligible
+} from '../lib/status/index.js';
+
+test('isValidStatus accepts canonical statuses and rejects others', () => {
+  assert.equal(isValidStatus('open'), true);
+  assert.equal(isValidStatus('resolved'), true);
+  assert.equal(isValidStatus('refunded'), true);
+  assert.equal(isValidStatus('cancelled'), false);
+  assert.equal(isValidStatus(''), false);
+  assert.equal(isValidStatus(undefined), false);
+});
+
+test('isTerminalStatus only treats resolved/refunded as terminal', () => {
+  assert.equal(isTerminalStatus('resolved'), true);
+  assert.equal(isTerminalStatus('refunded'), true);
+  assert.equal(isTerminalStatus('open'), false);
+  assert.equal(isTerminalStatus('expired'), false);
+});
+
+test('contractStatusToDb maps the on-chain enum exactly', () => {
+  // enum Status { None=0, Open=1, Resolved=2, Refunded=3 }
+  assert.equal(contractStatusToDb(0), null);
+  assert.equal(contractStatusToDb(1), 'open');
+  assert.equal(contractStatusToDb(2), 'resolved');
+  assert.equal(contractStatusToDb(3), 'refunded');
+  // accepts BigInt / numeric strings (ethers returns BigInt)
+  assert.equal(contractStatusToDb(1n), 'open');
+  assert.equal(contractStatusToDb('2'), 'resolved');
+  // unknown values fall back to null
+  assert.equal(contractStatusToDb(99), null);
+});
+
+test('CONTRACT_STATUS_MAP stays in sync with BOUNTY_STATUS', () => {
+  assert.equal(CONTRACT_STATUS_MAP[1], BOUNTY_STATUS.OPEN);
+  assert.equal(CONTRACT_STATUS_MAP[2], BOUNTY_STATUS.RESOLVED);
+  assert.equal(CONTRACT_STATUS_MAP[3], BOUNTY_STATUS.REFUNDED);
+});
+
+test('getStatusLabel returns friendly labels with a safe fallback', () => {
+  assert.equal(getStatusLabel('open'), 'Open');
+  assert.equal(getStatusLabel('resolved'), 'Resolved');
+  assert.equal(getStatusLabel('refunded'), 'Refunded');
+  assert.equal(getStatusLabel('nonsense'), 'Unknown');
+});
+
+test('deriveLifecycle reports an active open bounty before the deadline', () => {
+  const now = 1_000;
+  const lifecycle = deriveLifecycle({ status: 'open', deadline: 1_100 }, now);
+  assert.equal(lifecycle.state, 'open');
+  assert.equal(lifecycle.label, 'Open');
+  assert.equal(lifecycle.secondsRemaining, 100);
+  assert.equal(lifecycle.deadline, 1_100);
+});
+
+test('deriveLifecycle keeps terminal statuses terminal regardless of deadline', () => {
+  const now = 5_000;
+  for (const status of ['resolved', 'refunded']) {
+    const lifecycle = deriveLifecycle({ status, deadline: 1 }, now);
+    assert.equal(lifecycle.state, status);
+    assert.equal(lifecycle.secondsRemaining, 0);
+  }
+});
+
+test('deriveLifecycle marks open bounties expired only strictly after the deadline', () => {
+  const deadline = 2_000;
+  // exactly at the deadline -> still resolvable on-chain, so NOT expired
+  const atDeadline = deriveLifecycle({ status: 'open', deadline }, deadline);
+  assert.equal(atDeadline.state, 'open');
+  assert.equal(atDeadline.secondsRemaining, 0);
+
+  // one second past the deadline -> expired
+  const past = deriveLifecycle({ status: 'open', deadline }, deadline + 1);
+  assert.equal(past.state, 'expired');
+  assert.equal(past.label, 'Expired');
+  assert.equal(past.expiredAt, deadline);
+});
+
+test('deriveLifecycle handles missing/invalid deadlines without throwing', () => {
+  const lifecycle = deriveLifecycle({ status: 'open', deadline: undefined }, 1_000);
+  assert.equal(lifecycle.state, 'open');
+  assert.equal(lifecycle.secondsRemaining, null);
+  assert.equal(lifecycle.deadline, null);
+});
+
+test('isRefundEligible mirrors the contract refundExpired guard (strictly past deadline)', () => {
+  const deadline = 2_000;
+  // not open -> never eligible
+  assert.equal(isRefundEligible({ status: 'resolved', deadline }, deadline + 10), false);
+  // open but before deadline -> not eligible
+  assert.equal(isRefundEligible({ status: 'open', deadline }, deadline - 1), false);
+  // open exactly at deadline -> NOT eligible (on-chain would revert DeadlineNotReached)
+  assert.equal(isRefundEligible({ status: 'open', deadline }, deadline), false);
+  // open strictly past deadline -> eligible
+  assert.equal(isRefundEligible({ status: 'open', deadline }, deadline + 1), true);
+});
+
+test('isRefundEligible rejects bounties with no usable deadline', () => {
+  assert.equal(isRefundEligible({ status: 'open', deadline: undefined }, 9_999), false);
+  assert.equal(isRefundEligible({ status: 'open' }, 9_999), false);
+});

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isValidEmail } from '../lib/validation.js';
+import {
+  validateBytes32,
+  validateAmount,
+  validatePositiveNumber,
+  validateTxHash
+} from '../server/blockchain/validation.js';
+
+test('isValidEmail accepts well-formed addresses', () => {
+  assert.equal(isValidEmail('user@example.com'), true);
+  assert.equal(isValidEmail('  trimmed@example.com  '), true);
+  assert.equal(isValidEmail('a.b+tag@sub.domain.io'), true);
+});
+
+test('isValidEmail rejects malformed addresses and non-strings', () => {
+  assert.equal(isValidEmail('no-at-sign'), false);
+  assert.equal(isValidEmail('two@@example.com'), false);
+  assert.equal(isValidEmail('missing@tld'), false);
+  assert.equal(isValidEmail('spaces in@example.com'), false);
+  assert.equal(isValidEmail(''), false);
+  assert.equal(isValidEmail(null), false);
+  assert.equal(isValidEmail(42), false);
+});
+
+test('validateBytes32 accepts a 32-byte hex string and lowercases it', () => {
+  const value = '0x' + 'AB'.repeat(32);
+  assert.equal(validateBytes32(value), value.toLowerCase());
+});
+
+test('validateBytes32 rejects wrong lengths, missing prefix, and bad chars', () => {
+  assert.throws(() => validateBytes32('0x' + 'ab'.repeat(31)), /Invalid/);
+  assert.throws(() => validateBytes32('ab'.repeat(32)), /Invalid/);
+  assert.throws(() => validateBytes32('0x' + 'zz'.repeat(32)), /Invalid/);
+  assert.throws(() => validateBytes32(''), /required/);
+  assert.throws(() => validateBytes32(null), /required/);
+});
+
+test('validateAmount accepts positive integer strings only', () => {
+  assert.equal(validateAmount('1000000'), '1000000');
+  assert.throws(() => validateAmount('0'), /greater than 0/);
+  assert.throws(() => validateAmount('1.5'), /Invalid/);
+  assert.throws(() => validateAmount('-5'), /Invalid/);
+  assert.throws(() => validateAmount(''), /required/);
+  assert.throws(() => validateAmount(1000), /must be a string/);
+});
+
+test('validatePositiveNumber parses strings and rejects non-positive values', () => {
+  assert.equal(validatePositiveNumber('5'), 5);
+  assert.equal(validatePositiveNumber(2.5), 2.5);
+  assert.throws(() => validatePositiveNumber(0), /positive/);
+  assert.throws(() => validatePositiveNumber(-1), /positive/);
+  assert.throws(() => validatePositiveNumber('abc'), /positive/);
+});
+
+test('validateTxHash validates a 32-byte hash and normalises case', () => {
+  const hash = '0x' + 'CD'.repeat(32);
+  assert.equal(validateTxHash(hash), hash.toLowerCase());
+  assert.throws(() => validateTxHash('0x123'), /Invalid/);
+  assert.throws(() => validateTxHash(null), /required/);
+});


### PR DESCRIPTION
The escrow app handled real stablecoins with zero automated tests, and
"npm test" was broken (it pointed at a non-existent tests/ directory).

- Fix off-by-one in lib/status: deriveLifecycle/isRefundEligible marked
  bounties expired/refund-eligible at deadline <= now (inclusive), but the
  on-chain BountyEscrow.refundExpired guard is block.timestamp > deadline
  (strict) and resolve is still valid at == deadline. At exactly the
  deadline second the UI advertised a refund that would revert on-chain
  with DeadlineNotReached. Aligned both helpers to strict >.
- Extract the payout-routing PR issue parser into a pure, dependency-free
  module (integrations/github/issueRefs.js); client.js re-exports it for
  backwards compatibility.
- Add a runnable test suite (41 tests) over the pure money path: status
  lifecycle/refund eligibility, issue-reference parsing, amount/time
  formatting, and input validation.
- Fix the test script so npm test discovers and runs the suite.